### PR TITLE
Translated "member since" to "medlem sedan"

### DIFF
--- a/src/features/users/ProfileContent.tsx
+++ b/src/features/users/ProfileContent.tsx
@@ -70,7 +70,7 @@ function ProfileContent({ bio, url, joinDate, status }: ProfileContentProps): Re
             <Chip
               aria-label="Member join date"
               avatar={<AccessTimeIcon />}
-              label={`Member since ${joinDate.toLocaleDateString()}`}
+              label={`Medlem sedan ${joinDate.toLocaleDateString()}`}
               size="small"
             />
           </li>


### PR DESCRIPTION
Fix issue #124
Maybe you prefer "Blev medlem" instead? In that case I can change it to that. This was just the most direct translation.