### PR TITLE
Fixes to startpage

### DIFF
--- a/src/components/DynamicTitle.jsx
+++ b/src/components/DynamicTitle.jsx
@@ -1,7 +1,16 @@
 import React from 'react';
 import Typography from '@material-ui/core/Typography';
 
-const programmingIs = ['123', '223', '323'];
+const programmingIs = [
+  'roligt!',
+  'krångligt (ibland)',
+  'framtiden',
+  'förvånansvärt enkelt',
+  'välbetalt ;)',
+  'spännande',
+  'en flex att kunna B)',
+  'viktigt',
+];
 
 class DynamicTitle extends React.Component {
   state = {

--- a/src/components/DynamicTitle.jsx
+++ b/src/components/DynamicTitle.jsx
@@ -1,58 +1,39 @@
 import React from 'react';
 import Typography from '@material-ui/core/Typography';
 
-const programmingIs = [
-  'roligt!',
-  'krångligt (ibland)',
-  'framtiden',
-  'förvånansvärt enkelt',
-  'välbetalt ;)',
-  'spännande',
-  'en flex att kunna B)',
-  'viktigt',
-];
+const programmingIs = ['123', '223', '323'];
 
 class DynamicTitle extends React.Component {
-  constructor(props) {
-    super(props);
-    const firstIndex = Math.floor(Math.random() * programmingIs.length);
-
-    this.interval = null;
-    this.state = {
-      titleWordIndex: Math.floor(firstIndex),
-      titleWord: programmingIs[firstIndex],
-      letters: '',
-      letterIndex: 0,
-      erasing: false,
-    };
-  }
+  state = {
+    erasing: false,
+    letterIndex: 0,
+    titleWordIndex: Math.floor(Math.floor(Math.random() * programmingIs.length)),
+  };
+  interval = null;
 
   componentDidMount() {
     this.interval = setInterval(() => {
-      // If we are erasing and have zero letters, choose a new word.
-      if (this.state.letterIndex <= 0 && this.state.erasing === true) {
-        let newWordIndex = this.state.titleWordIndex + 1;
-        if (newWordIndex > programmingIs.length - 1) {
-          newWordIndex = 0;
+      // if erasing
+      if (this.state.erasing) {
+        // if at -2 (meaning a little pause after 0)
+        if (this.state.letterIndex === -2) {
+          // choose new word, set erase to false and return
+          this.setState({
+            erasing: false,
+            titleWordIndex: this.state.titleWordIndex + 1 === programmingIs.length ? 0 : this.state.titleWordIndex + 1,
+          });
+          return;
         }
-        this.setState({ titleWord: programmingIs[newWordIndex], titleWordIndex: newWordIndex });
-      }
-
-      const spliceAt = this.state.letterIndex < 0 ? 0 : this.state.letterIndex;
-      const newLetters = this.state.titleWord.slice(0, spliceAt);
-
-      let newIndex = 0;
-      if (this.state.erasing === true) {
-        newIndex = this.state.letterIndex - 1;
+        // else lower
+        else {
+          this.setState({ letterIndex: this.state.letterIndex - 1 });
+        }
       } else {
-        newIndex = this.state.letterIndex + 1;
-      }
-      this.setState({ letters: newLetters, letterIndex: newIndex });
-
-      if (newIndex > this.state.titleWord.length + 5) {
-        this.setState({ erasing: true });
-      } else if (newIndex < -1) {
-        this.setState({ erasing: false });
+        this.setState({
+          // erasing is true if 5 characters longer than word, implying a little pause
+          erasing: this.state.letterIndex === programmingIs[this.state.titleWordIndex].length + 5,
+          letterIndex: this.state.letterIndex + 1,
+        });
       }
     }, 100);
   }
@@ -65,31 +46,36 @@ class DynamicTitle extends React.Component {
     return (
       <>
         <Typography
-          style={{ fontSize: this.props.titleSize, marginBottom: 10, color: 'white', fontWeight: 'bold' }}
-          variant="h2"
+          style={{
+            color: 'white',
+            fontWeight: 'bold',
+            marginBottom: '0.5rem',
+          }}
+          variant="h4"
         >
           Programmering är...
         </Typography>
         <div
           style={{
-            width: '100%',
-            marginBottom: 24,
             background: 'rgba(255,255,255, 0.5)',
-            padding: 3,
-            borderRadius: 6,
+            borderRadius: '0.5rem',
+            marginBottom: 24,
             overflow: 'hidden',
           }}
         >
           <Typography
             style={{
-              width: '150vw',
-              fontSize: this.props.titleSize - 5,
-              fontFamily: 'monospace',
               color: 'white',
+              fontFamily: 'monospace',
+              lineHeight: 'inherit',
+              overflowWrap: 'anywhere',
               paddingLeft: 12,
+              width: '100%',
             }}
+            variant="h4"
           >
-            {'> ' + this.state.letters}
+            {'> ' + programmingIs[this.state.titleWordIndex].substring(0, this.state.letterIndex)}
+            {/* {'> ' + this.state.letters} */}
           </Typography>
         </div>
       </>

--- a/src/pages/Startpage.tsx
+++ b/src/pages/Startpage.tsx
@@ -1,184 +1,144 @@
-import React, { useEffect, useState } from 'react';
-
 import Button from '@material-ui/core/Button';
 import DynamicTitle from 'components/DynamicTitle';
 import Grid from '@material-ui/core/Grid';
 import Hidden from '@material-ui/core/Hidden';
 import { Link } from 'react-router-dom';
+import React from 'react';
 import Typography from '@material-ui/core/Typography';
 
-const CenterWrapper: React.FC = ({ children }) => (
-  <Grid container justify="center">
-    <Grid container item justify="center" xs={10}>
-      {children}
-    </Grid>
-  </Grid>
-);
-
-export default function Startpage() {
-  // With hook determine width of window
-  const [windowWidth, setWindowWidth] = useState(window.innerWidth);
-  useEffect(() => {
-    function handleResize() {
-      setWindowWidth(window.innerWidth);
-    }
-
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, []);
-
-  const titleSize = windowWidth > 400 ? 40 : 30;
-  const subtitleSize = windowWidth > 400 ? 30 : 20;
-  const descSize = windowWidth > 400 ? 18 : 12;
-  // const buttonSize = windowWidth > 400 ? 16 : 10;
-
-  return (
-    <Grid container item justify="space-between">
-      <Grid container style={{ background: '#05379c', paddingTop: 60, paddingBottom: 50, width: '100%' }}>
-        <CenterWrapper>
-          <Grid alignItems="center" container justify="space-between">
-            <Hidden smDown>
-              <Grid item lg={6} md={5}>
-                <div>
-                  <img alt="frontPage" src={require('resources/images/FrontPage.png')} style={{ width: '100%' }} />
-                </div>
-              </Grid>
-            </Hidden>
-
-            <Grid item lg={5} md={7} xs={12}>
-              <div>
-                <DynamicTitle titleSize={titleSize} />
-
-                <Typography
-                  gutterBottom
-                  style={{ fontSize: subtitleSize, color: 'rgba(255,255,255,0.85)', fontWeight: 'bold' }}
-                  variant="h3"
-                >
-                  Här kan du lära dig, <br /> dela med dig av och hjälpa
-                  <br /> andra med programmering.{' '}
-                </Typography>
-
-                <Typography style={{ fontSize: descSize, marginBottom: 40, color: 'rgba(255,255,255,0.85)' }}>
-                  Vi är ett svenskt ideellt ungdomsförbund för programmerings- och teknikintresserade ungdomar. Bli
-                  medlem och ta del av vår community!{' '}
-                  <span aria-label="star" role="img">
-                    🌟
-                  </span>
-                </Typography>
-                <Grid container justify="space-evenly">
-                  <Grid item xs={4}>
-                    <Link to="/bli-medlem">
-                      <Button
-                        color="primary"
-                        fullWidth
-                        size="large"
-                        style={{ width: '90%' }}
-                        // style={{ fontSize: buttonSize }}
-                        variant="contained"
-                      >
-                        Bli medlem!
-                      </Button>
-                    </Link>
-                  </Grid>
-                  <Grid item xs={4}>
-                    <Link to="/logga-in">
-                      <Button
-                        size="large"
-                        style={{
-                          // fontSize: buttonSize,
-                          // color: 'rgba(255,255,255,0.9)',
-                          width: '90%',
-                          // border: '2px solid #cccccc',
-                        }}
-                        variant="contained"
-                      >
-                        Logga in
-                      </Button>
-                    </Link>
-                  </Grid>
-                  <Grid item xs={4}>
-                    <Link to="/om-oss">
-                      <Button
-                        size="large"
-                        style={{
-                          // fontSize: buttonSize,
-                          // color: 'rgba(255,255,255,0.9)',
-                          width: '90%',
-                          // border: '2px solid #cccccc',
-                        }}
-                        variant="contained"
-                      >
-                        Om oss
-                      </Button>
-                    </Link>
-                  </Grid>
-                </Grid>
-              </div>
-            </Grid>
-          </Grid>
-        </CenterWrapper>
-      </Grid>
-
-      <div
-        style={{
-          background: '#05379c',
-          borderBottomLeftRadius: '50%',
-          borderBottomRightRadius: '50%',
-          height: 20,
-          width: '100%',
-          marginTop: -2,
-        }}
-      />
-
-      <Grid container justify="center" style={{ flex: 1 }}>
-        <Grid container justify="center" style={{ paddingTop: 140, paddingBottom: 80 }}>
-          <Grid container item justify="center" md={3} xs={7}>
+const Startpage = () => (
+  <Grid container item justify="space-between">
+    <Grid
+      container
+      justify="center"
+      style={{
+        background: '#05379c',
+        paddingBottom: 50,
+        paddingTop: 60,
+        width: '100%',
+      }}
+    >
+      <Grid alignItems="center" container justify="space-between" xs={10}>
+        <Hidden smDown>
+          <Grid item lg={6} md={5}>
             <div>
-              <img
-                alt="underConstruction"
-                src={require('resources/images/underConstruction.png')}
-                style={{ width: '100%' }}
-              />
+              <img alt="frontPage" src={require('resources/images/FrontPage.png')} style={{ width: '100%' }} />
             </div>
           </Grid>
-
-          <Grid container item justify="center" lg={4} md={4} sm={8} xs={9}>
-            <Typography
-              gutterBottom
-              variant="h4"
-              // style={{ fontSize: 28, color: '#434343', fontWeight: 'bold' }}
-            >
-              Arbete pågår!
-            </Typography>
-
-            <Typography
-              gutterBottom
-              // style={{ fontSize: 16, marginBottom: 10, color: '#434343' }}
-            >
-              Detta är den första versionen av digitalungdom.se så det saknas forfarande många planerade funktioner. Vi
-              arbetar dock hårt med hemsidan och fler funktioner kommer snart!
+        </Hidden>
+        <Grid item lg={5} md={7} xs={12}>
+          <div>
+            <DynamicTitle />
+            <Typography gutterBottom style={{ color: 'rgba(255,255,255,0.85)', fontWeight: 'bold' }} variant="h5">
+              Här kan du lära dig, <br /> dela med dig av och hjälpa
+              <br /> andra med programmering.{' '}
             </Typography>
             <Typography
-              gutterBottom
-              variant="body1"
-              // style={{ fontSize: 16, marginBottom: 10, color: '#434343' }}
+              component="p"
+              style={{
+                color: 'rgba(255,255,255,0.85)',
+                fontWeight: 'normal',
+                marginBottom: 40,
+              }}
+              variant="h6"
             >
-              För tillfället kan ni njuta av Agora (vårt forum) och faktumet att ni kan ha i princip vilket användarnamn
-              som helst!{' '}
-              <span aria-label="cool" role="img">
-                😎
+              Vi är ett svenskt ideellt ungdomsförbund för programmerings- och teknikintresserade ungdomar. Bli medlem
+              och ta del av vår community!{' '}
+              <span aria-label="star" role="img">
+                🌟
               </span>
             </Typography>
-            <Grid container style={{ marginTop: 30 }}>
-              <Link to="/bli-medlem">
-                <Button color="primary" size="large" variant="contained">
-                  Skapa ett konto
-                </Button>
-              </Link>
+            <Grid container justify="space-evenly">
+              <Grid item xs={4}>
+                <Link to="/bli-medlem">
+                  <Button color="primary" fullWidth size="large" style={{ width: '90%' }} variant="contained">
+                    Bli medlem!
+                  </Button>
+                </Link>
+              </Grid>
+              <Grid item xs={4}>
+                <Link to="/logga-in">
+                  <Button
+                    size="large"
+                    style={{
+                      width: '90%',
+                    }}
+                    variant="contained"
+                  >
+                    Logga in
+                  </Button>
+                </Link>
+              </Grid>
+              <Grid item xs={4}>
+                <Link to="/om-oss">
+                  <Button
+                    size="large"
+                    style={{
+                      width: '90%',
+                    }}
+                    variant="contained"
+                  >
+                    Om oss
+                  </Button>
+                </Link>
+              </Grid>
             </Grid>
+          </div>
+        </Grid>
+      </Grid>
+    </Grid>
+    <div
+      style={{
+        background: '#05379c',
+        borderBottomLeftRadius: '50%',
+        borderBottomRightRadius: '50%',
+        height: 24,
+        width: '100%',
+      }}
+    />
+    <Grid container justify="center" style={{ flex: 1 }}>
+      <Grid
+        container
+        justify="center"
+        style={{
+          paddingBottom: 80,
+          paddingTop: 140,
+        }}
+      >
+        <Grid container item justify="center" md={3} xs={7}>
+          <div>
+            <img
+              alt="underConstruction"
+              src={require('resources/images/underConstruction.png')}
+              style={{ width: '100%' }}
+            />
+          </div>
+        </Grid>
+        <Grid container item justify="center" lg={4} md={4} sm={8} xs={9}>
+          <Typography gutterBottom variant="h4">
+            Arbete pågår!
+          </Typography>
+          <Typography gutterBottom>
+            Detta är den andra versionen av digitalungdom.se så det saknas forfarande många planerade funktioner. Vi
+            arbetar dock hårt med hemsidan och fler funktioner kommer snart!
+          </Typography>
+          <Typography gutterBottom variant="body1">
+            För tillfället kan ni njuta av Agora (vårt forum) och faktumet att ni kan ha i princip vilket användarnamn
+            som helst!{' '}
+            <span aria-label="cool" role="img">
+              😎
+            </span>
+          </Typography>
+          <Grid container style={{ marginTop: 30 }}>
+            <Link to="/bli-medlem">
+              <Button color="primary" size="large" variant="contained">
+                Skapa ett konto
+              </Button>
+            </Link>
           </Grid>
         </Grid>
       </Grid>
     </Grid>
-  );
-}
+  </Grid>
+);
+export default Startpage;


### PR DESCRIPTION
I made some font-sizes more user friendly as they depend on Material UI's `rem` font-sizes. This means that it will look roughly the same on most devices. I also fixed so that the dynamic title will loop over all words / sentences.

This fixes #90 #99.

This pull request (PR) should be squashed. There was a mistake in the first commit.