### PR TITLE
Potential fix #148

### DIFF
--- a/src/features/Header/index.tsx
+++ b/src/features/Header/index.tsx
@@ -187,7 +187,7 @@ function Header(): JSX.Element {
                           })),
                         ),
                       )
-                      .catch((err) => reject(err)),
+                      .catch(console.error),
                   )
                 }
                 limit={10}


### PR DESCRIPTION
I've tried to fix #148. If you set the `token_expiry` in localStorage to an old date (for example, `0`, or more generally `Date.now() - 900*1000`), and set the `refresh_token` to an invalid value, such as `thisIsNotARealToken` then you should automatically be logged out.